### PR TITLE
Refactored to use an object model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 *.iml
+vendor

--- a/src/Error.php
+++ b/src/Error.php
@@ -5,9 +5,9 @@ namespace TreeRoute;
 /**
  * This model represents an error generated while attempting to dispatch a Router.
  *
- * @see Router::dispatch()
+ * @see Result::$error
  */
-class Error extends Result
+class Error
 {
     /**
      * @param int $code

--- a/src/Error.php
+++ b/src/Error.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace TreeRoute;
+
+/**
+ * This model represents an error generated while attempting to dispatch a Router.
+ *
+ * @see Router::dispatch()
+ */
+class Error extends Result
+{
+    /**
+     * @param int $code
+     * @param string $message
+     */
+    public function __construct($code, $message)
+    {
+        $this->code = $code;
+        $this->message = $message;
+    }
+
+    /**
+     * @var int error code
+     */
+    public $code;
+
+    /**
+     * @var string error message
+     */
+    public $message;
+
+    /**
+     * @var string[] list of allowed HTTP methods
+     */
+    public $allowed = array();
+}

--- a/src/Match.php
+++ b/src/Match.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TreeRoute;
+
+/**
+ * This model represents the result of an attempted match.
+ *
+ * @see Router::match()
+ */
+class Match
+{
+    /**
+     * @param string     $route
+     * @param callable[] $methods
+     * @param string[]   $params
+     */
+    public function __construct($route, $methods, $params)
+    {
+        $this->route = $route;
+        $this->methods = $methods;
+        $this->params = $params;
+    }
+
+    /**
+     * @var string the route expression that was matched
+     */
+    public $route;
+
+    /**
+     * @var callable[] map where HTTP method name => callable
+     */
+    public $methods;
+
+    /**
+     * @var string[] map where parameter name => parameter
+     */
+    public $params;
+}

--- a/src/Result.php
+++ b/src/Result.php
@@ -33,4 +33,9 @@ class Result
      * @var callable
      */
     public $handler;
+
+    /**
+     * @var Error|null error information (or NULL, if this Result is a success)
+     */
+    public $error;
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace TreeRoute;
+
+/**
+ * This class represents the result of an attempted Router dispatch.
+ *
+ * @see Router::dispatch()
+ */
+class Result
+{
+    /**
+     * @var string the attempted URL
+     */
+    public $url;
+
+    /**
+     * @var string the attempted HTTP method
+     */
+    public $method;
+
+    /**
+     * @var string matched route pattern
+     */
+    public $route;
+
+    /**
+     * @var string[] map where parameter name => parameter value
+     */
+    public $params = array();
+
+    /**
+     * @var callable
+     */
+    public $handler;
+}

--- a/src/Route.php
+++ b/src/Route.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TreeRoute;
+
+/**
+ * This class represents a route, or part of a route, within a Router.
+ */
+class Route
+{
+    /**
+     * @var string route pattern
+     */
+    public $route;
+
+    /**
+     * @var callable[] map where HTTP method => callable method handler
+     */
+    public $methods = array();
+
+    /**
+     * @var string|null parameter name (or NULL, if this route does not match a parameter)
+     */
+    public $name;
+
+    /**
+     * @var Route[] list of nested Route instances
+     */
+    public $childs = array();
+
+    /**
+     * @var Route[] map where regular expression => nested Route instance
+     */
+    public $regexps = array();
+
+    /**
+     * @var Route root of other possible routes
+     */
+    public $others;
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -140,36 +140,31 @@ class Router
      * @param string $method HTTP method name
      * @param string $url
      *
-     * @return Result|Error
+     * @return Result
      */
     public function dispatch($method, $url)
     {
         $match = $this->match($url);
 
+        $result = new Result();
+        $result->url = $url;
+        $result->method = $method;
+
         if (!$match) {
-            $result = new Error(404, 'Not Found');
-            $result->url = $url;
-            $result->method = $method;
-            return $result;
+            $result->error = new Error(404, 'Not Found');
         } else {
+            $result->route = $match->route;
+            $result->params = $match->params;
+
             if (isset($match->methods[$method])) {
-                $result = new Result();
-                $result->url = $url;
-                $result->method = $method;
-                $result->route = $match->route;
-                $result->params = $match->params;
                 $result->handler = $match->methods[$method];
-                return $result;
             } else {
-                $result = new Error(405, 'Method Not Allowed');
-                $result->url = $url;
-                $result->method = $method;
-                $result->route = $match->route;
-                $result->params = $match->params;
-                $result->allowed = array_keys($match->methods);
-                return $result;
+                $result->error = new Error(405, 'Method Not Allowed');
+                $result->error->allowed = array_keys($match->methods);
             }
         }
+
+        return $result;
     }
 
     /**

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,2 +1,4 @@
 <?php
 // This is global bootstrap for autoloading
+
+require dirname(__DIR__) . '/vendor/autoload.php';

--- a/tests/unit/RouterTest.php
+++ b/tests/unit/RouterTest.php
@@ -18,22 +18,20 @@ class RouterTest extends \Codeception\TestCase\Test
     }
 
     /**
-     * @param $result
-     * @param int $code
+     * @param \TreeRoute\Result $result
+     * @param int               $code
      */
-    private function assertIsError($result, $code)
+    private function assertIsError(\TreeRoute\Result $result, $code)
     {
-        $this->assertInstanceOf('TreeRoute\Error', $result);
-
-        if ($result instanceof TreeRoute\Error) {
-            $this->assertEquals($code, $result->code);
-        }
+        $this->assertEquals($code, $result->error->code);
     }
 
-    private function assertIsNotError($result)
+    /**
+     * @param \TreeRoute\Result $result
+     */
+    private function assertIsNotError(\TreeRoute\Result $result)
     {
-        $this->assertInstanceOf('TreeRoute\Result', $result);
-        $this->assertNotInstanceOf('TreeRoute\Error', $result);
+        $this->assertEmpty($result->error);
     }
 
     public function testRouter()
@@ -56,7 +54,7 @@ class RouterTest extends \Codeception\TestCase\Test
         $this->specify('should return 405 error for unsupported method', function () use ($router) {
             $result = $router->dispatch('POST', '/');
             $this->assertIsError($result, 405);
-            $this->assertEquals(['GET'], $result->allowed);
+            $this->assertEquals(['GET'], $result->error->allowed);
         });
 
         $this->specify('should define route with short methods', function () use ($router) {

--- a/tests/unit/RouterTest.php
+++ b/tests/unit/RouterTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class RouterTest extends \Codeception\TestCase\Test
 {
     use \Codeception\Specify;
@@ -18,40 +17,61 @@ class RouterTest extends \Codeception\TestCase\Test
     {
     }
 
+    /**
+     * @param $result
+     * @param int $code
+     */
+    private function assertIsError($result, $code)
+    {
+        $this->assertInstanceOf('TreeRoute\Error', $result);
+
+        if ($result instanceof TreeRoute\Error) {
+            $this->assertEquals($code, $result->code);
+        }
+    }
+
+    private function assertIsNotError($result)
+    {
+        $this->assertInstanceOf('TreeRoute\Result', $result);
+        $this->assertNotInstanceOf('TreeRoute\Error', $result);
+    }
+
     public function testRouter()
     {
         $router = new \TreeRoute\Router();
+
         $router->addRoute(['GET'], '/', 'handler0');
 
         $this->specify('should find existed route', function () use ($router) {
             $result = $router->dispatch('GET', '/');
-            $this->assertEquals('handler0', $result['handler']);
+            $this->assertIsNotError($result);
+            $this->assertEquals('handler0', $result->handler);
         });
 
         $this->specify('should return 404 error for not existed route', function () use ($router) {
             $result = $router->dispatch('GET', '/not/existed/url');
-            $this->assertEquals(404, $result['error']['code']);
+            $this->assertIsError($result, 404);
         });
 
         $this->specify('should return 405 error for unsupported method', function () use ($router) {
             $result = $router->dispatch('POST', '/');
-            $this->assertEquals(405, $result['error']['code']);
-            $this->assertEquals(['GET'], $result['allowed']);
+            $this->assertIsError($result, 405);
+            $this->assertEquals(['GET'], $result->allowed);
         });
 
         $this->specify('should define route with short methods', function () use ($router) {
             $router->post('/create', 'handler1');
             $result = $router->dispatch('POST', '/create');
 
-            $this->assertEquals('handler1', $result['handler']);
+            $this->assertEquals('handler1', $result->handler);
         });
 
         $this->specify('should extract route params', function () use ($router) {
             $router->get('/news/{id}', 'handler2');
             $result = $router->dispatch('GET', '/news/1');
 
-            $this->assertEquals('handler2', $result['handler']);
-            $this->assertEquals('1', $result['params']['id']);
+            $this->assertEquals('handler2', $result->handler);
+            $this->assertEquals('1', $result->params['id']);
         });
 
         $this->specify('should match regexp in params', function () use ($router) {
@@ -59,32 +79,32 @@ class RouterTest extends \Codeception\TestCase\Test
             $router->get('/users/{id:^[0-9]+$}', 'handler4');
 
             $result = $router->dispatch('GET', '/users/@test');
-            $this->assertEquals(404, $result['error']['code']);
+            $this->assertIsError($result, 404);
 
             $result = $router->dispatch('GET', '/users/bob');
-            $this->assertEquals('handler3', $result['handler']);
-            $this->assertEquals('bob', $result['params']['name']);
+            $this->assertEquals('handler3', $result->handler);
+            $this->assertEquals('bob', $result->params['name']);
 
             $result = $router->dispatch('GET', '/users/123');
-            $this->assertEquals('handler4', $result['handler']);
-            $this->assertEquals('123', $result['params']['id']);
+            $this->assertEquals('handler4', $result->handler);
+            $this->assertEquals('123', $result->params['id']);
         });
 
         $this->specify('should give greater priority to statically defined route', function () use ($router) {
             $router->get('/users/help', 'handler5');
             $result = $router->dispatch('GET', '/users/help');
-            $this->assertEquals('handler5', $result['handler']);
-            $this->assertEmpty($result['params']);
+            $this->assertEquals('handler5', $result->handler);
+            $this->assertEmpty($result->params);
         });
 
         $this->specify('should save and restore routes', function () use ($router) {
             $routes = $router->getRoutes();
             $router = new \TreeRoute\Router();
             $result = $router->dispatch('GET', '/');
-            $this->assertEquals(404, $result['error']['code']);
+            $this->assertIsError($result, 405);
             $router->setRoutes($routes);
             $result = $router->dispatch('GET', '/');
-            $this->assertEquals('handler0', $result['handler']);
+            $this->assertEquals('handler0', $result->handler);
         });
     }
 }

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -1,4 +1,2 @@
 <?php
 // Here you can initialize variables that will be available to your tests
-
-require __DIR__ . '/../../src/Router.php';


### PR DESCRIPTION
Refactored to use an object model, avoiding arrays (and array references) and adding annotations for IDE support.

Should be slightly faster in PHP 5.6, and may be slightly slower in older versions - should also be more memory efficient in PHP 5.4 and newer. (I haven't forked/updated the benchmarks)

This of course is a BC break, as it changes the API completely, as reflected by the updated unit-test.
